### PR TITLE
Updates to edx sync

### DIFF
--- a/course_catalog/constants.py
+++ b/course_catalog/constants.py
@@ -12,6 +12,12 @@ class PlatformType(Enum):
     mitx = "mitx"
 
 
+MIT_OWNER_KEYS = [
+    'MITx',
+    'MITx_PRO',
+]
+
+
 semester_mapping = {
     "1T": "spring",
     "2T": "summer",

--- a/course_catalog/settings.py
+++ b/course_catalog/settings.py
@@ -392,5 +392,6 @@ MANDATORY_SETTINGS = [
     'SECRET_KEY',
 ]
 
+EDX_API_URL = get_string('EDX_API_URL', None)
 EDX_API_CLIENT_ID = get_string('EDX_API_CLIENT_ID', None)
 EDX_API_CLIENT_SECRET = get_string('EDX_API_CLIENT_SECRET', None)

--- a/course_catalog/tasks.py
+++ b/course_catalog/tasks.py
@@ -1,12 +1,16 @@
 """
 course_catalog tasks
 """
+import logging
+
 import requests
 from celery.task import task
 
 from course_catalog.settings import EDX_API_URL
 from course_catalog.tasks_helpers import get_access_token, parse_mitx_json_data
-from course_catalog.utils import log
+
+
+log = logging.getLogger(__name__)
 
 
 @task

--- a/course_catalog/tasks.py
+++ b/course_catalog/tasks.py
@@ -6,6 +6,7 @@ from celery.task import task
 
 from course_catalog.settings import EDX_API_URL
 from course_catalog.tasks_helpers import get_access_token, parse_mitx_json_data
+from course_catalog.utils import log
 
 
 @task
@@ -22,6 +23,7 @@ def get_edx_data():
             for course_data in response.json()["results"]:
                 parse_mitx_json_data(course_data)
         else:
+            log.exception("Bad response status %s for %s", str(response.status_code), url)
             break
 
         url = response.json()["next"]

--- a/course_catalog/tasks.py
+++ b/course_catalog/tasks.py
@@ -18,10 +18,10 @@ def get_edx_data():
         # print(url)
         access_token = get_access_token()
         response = requests.get(url, headers={"Authorization": "JWT " + access_token})
-        if response.status_code == 429:
-            break
-        else:
+        if response.status_code == 200:
             for course_data in response.json()["results"]:
                 parse_mitx_json_data(course_data)
+        else:
+            break
 
         url = response.json()["next"]

--- a/course_catalog/tasks.py
+++ b/course_catalog/tasks.py
@@ -4,6 +4,7 @@ course_catalog tasks
 import requests
 from celery.task import task
 
+from course_catalog.settings import EDX_API_URL
 from course_catalog.tasks_helpers import get_access_token, parse_mitx_json_data
 
 
@@ -12,12 +13,15 @@ def get_edx_data():
     """
     Task to sync mitx data with the database
     """
-    url = "https://api.edx.org/catalog/v1/catalogs/248/courses"
+    url = EDX_API_URL
     while url:
         # print(url)
         access_token = get_access_token()
         response = requests.get(url, headers={"Authorization": "JWT " + access_token})
-        for course_data in response.json()["results"]:
-            parse_mitx_json_data(course_data)
+        if response.status_code == 429:
+            break
+        else:
+            for course_data in response.json()["results"]:
+                parse_mitx_json_data(course_data)
 
         url = response.json()["next"]

--- a/course_catalog/tasks_helpers.py
+++ b/course_catalog/tasks_helpers.py
@@ -2,6 +2,7 @@
 course_catalog helper functions for tasks
 """
 import json
+import re
 
 from datetime import datetime
 
@@ -9,7 +10,7 @@ import pytz
 import requests
 from django.db import transaction
 
-from course_catalog.constants import PlatformType, semester_mapping
+from course_catalog.constants import PlatformType, semester_mapping, MIT_OWNER_KEYS
 from course_catalog.models import Course, CourseTopic, CourseInstructor, CoursePrice
 from course_catalog.serializers import CourseSerializer
 from course_catalog.settings import EDX_API_CLIENT_ID, EDX_API_CLIENT_SECRET
@@ -33,6 +34,11 @@ def parse_mitx_json_data(course_data):
     """
     Main function to parse edx json data
     """
+
+    # Make sure this is an MIT course
+    if not is_mit_course(course_data):
+        return
+
     # Make changes atomically so we don't end up with partially saved/deleted data
     with transaction.atomic():
 
@@ -60,10 +66,7 @@ def parse_mitx_json_data(course_data):
             except Course.DoesNotExist:
                 course_instance = None
 
-            try:
-                year = int(course_run_key[-4:])
-            except ValueError:
-                year = datetime.strptime(course_run.get("start"), "%Y-%m-%dT%H:%M:%S.%fZ").year
+            year, semester = get_year_and_semester(course_run, course_run_key)
 
             course_fields = {
                 "course_id": course_run_key,
@@ -71,7 +74,7 @@ def parse_mitx_json_data(course_data):
                 "short_description": course_run.get("short_description"),
                 "full_description": course_run.get("full_description"),
                 "level": course_run.get("level_type"),
-                "semester": semester_mapping.get(course_run_key[-6:-4], None),
+                "semester": semester,
                 "language": course_run.get("content_language"),
                 "platform": PlatformType.mitx.value,
                 "year": year,
@@ -79,14 +82,15 @@ def parse_mitx_json_data(course_data):
                 "end_date": course_run.get("end"),
                 "enrollment_start": course_run.get("enrollment_start"),
                 "enrollment_end": course_run.get("enrollment_end"),
-                "image_src": course_run.get("image").get("src"),
-                "image_description": course_run.get("image").get("description"),
+                "image_src": (course_run.get("image") or {}).get("src"),
+                "image_description": (course_run.get("image") or {}).get("description"),
                 "last_modified": max_modified,
                 "raw_json": json.dumps(course_data),
             }
 
             course_serializer = CourseSerializer(data=course_fields, instance=course_instance)
             if not course_serializer.is_valid():
+                # print(course_serializer.errors)
                 # print("(" + course_data.get("key") + ", " + course_run_key + ") is not valid")
                 continue
             course = course_serializer.save()
@@ -122,3 +126,34 @@ def handle_many_to_many_fields(course, course_data, course_run):
             upgrade_deadline=price.get("upgrade_deadline"),
         )
         course.prices.add(course_price)
+
+
+def is_mit_course(course_data):
+    """
+    Helper function to determine if a course is an MIT course
+    """
+    for owner in course_data.get("owners"):
+        if owner["key"] in MIT_OWNER_KEYS:
+            return True
+    return False
+
+
+def get_year_and_semester(course_run, course_run_key):
+    """
+    Parse year and semester out of course run key.
+    If course run key cannot be parsed attempt to get year from start
+    """
+    match = re.search("[1|2|3]T[0-9]{4}", course_run_key)
+    if match:
+        year = int(match.group(0)[-4:])
+        semester = semester_mapping.get(match.group(0)[-6:-4])
+    else:
+        semester = None
+        if course_run.get("start"):
+            year = course_run.get("start")[:4]
+        else:
+            year = None
+    # match = re.search("[0-9]{4}_Q[1|2|3]", course_run_key)
+
+    print(f"{course_run_key} {year} {semester}")
+    return year, semester

--- a/course_catalog/tasks_helpers.py
+++ b/course_catalog/tasks_helpers.py
@@ -2,6 +2,7 @@
 course_catalog helper functions for tasks
 """
 import json
+import logging
 import re
 
 from datetime import datetime
@@ -14,7 +15,9 @@ from course_catalog.constants import PlatformType, semester_mapping, MIT_OWNER_K
 from course_catalog.models import Course, CourseTopic, CourseInstructor, CoursePrice
 from course_catalog.serializers import CourseSerializer
 from course_catalog.settings import EDX_API_CLIENT_ID, EDX_API_CLIENT_SECRET
-from course_catalog.utils import log
+
+
+log = logging.getLogger(__name__)
 
 
 def get_access_token():

--- a/course_catalog/tasks_helpers.py
+++ b/course_catalog/tasks_helpers.py
@@ -153,7 +153,6 @@ def get_year_and_semester(course_run, course_run_key):
             year = course_run.get("start")[:4]
         else:
             year = None
-    # match = re.search("[0-9]{4}_Q[1|2|3]", course_run_key)
 
-    print(f"{course_run_key} {year} {semester}")
+    # print(f"{course_run_key} {year} {semester}")
     return year, semester

--- a/course_catalog/tasks_helpers.py
+++ b/course_catalog/tasks_helpers.py
@@ -14,6 +14,7 @@ from course_catalog.constants import PlatformType, semester_mapping, MIT_OWNER_K
 from course_catalog.models import Course, CourseTopic, CourseInstructor, CoursePrice
 from course_catalog.serializers import CourseSerializer
 from course_catalog.settings import EDX_API_CLIENT_ID, EDX_API_CLIENT_SECRET
+from course_catalog.utils import log
 
 
 def get_access_token():
@@ -92,6 +93,7 @@ def parse_mitx_json_data(course_data):
             if not course_serializer.is_valid():
                 # print(course_serializer.errors)
                 # print("(" + course_data.get("key") + ", " + course_run_key + ") is not valid")
+                log.exception("Course %s is not valid: %s", course_run_key, course_serializer.errors)
                 continue
             course = course_serializer.save()
             # print("(" + course_data.get("key") + ", " + course_run_key + ") is valid")

--- a/tasks_helpers_test.py
+++ b/tasks_helpers_test.py
@@ -1,0 +1,255 @@
+"""
+Test course_catalog tasks_helpers
+"""
+import copy
+
+from django.test import TestCase
+
+from course_catalog.models import Course
+from course_catalog.tasks_helpers import parse_mitx_json_data
+
+
+class MITXParseTest(TestCase):
+    """
+    Tests EDX parsing
+    """
+
+    def setUp(self):
+        """
+        Set up the tests
+        """
+        self.valid_data = {
+            "key": "MITx+15.071x",
+            "uuid": "ff1df27b-3c97-42ee-a9b3-e031ffd41a4f",
+            "title": "The Analytics Edge",
+            "course_runs": [{
+                "key": "course-v1:MITx+15.071x+1T2019",
+                "uuid": "f4b7be41-352f-4c0d-afc5-424dcf498ed6",
+                "title": "The Analytics Edge",
+                "image": {
+                    "src": "https://prod-discovery.edx-cdn.org/media/course/image/"
+                           "ff1df27b-3c97-42ee-a9b3-e031ffd41a4f-747c9c2f216e.small.jpg",
+                    "height": None,
+                    "width": None,
+                    "description": None
+                },
+                "short_description": "short_description",
+                "marketing_url": "marketing_url",
+                "seats": [{
+                    "type": "verified",
+                    "price": "150.00",
+                    "currency": "USD",
+                    "upgrade_deadline": "2019-03-20T15:00:00Z",
+                    "credit_provider": None,
+                    "credit_hours": None,
+                    "sku": "E110665",
+                    "bulk_sku": "5B37144"
+                }, {
+                    "type": "audit",
+                    "price": "0.00",
+                    "currency": "USD",
+                    "upgrade_deadline": None,
+                    "credit_provider": None,
+                    "credit_hours": None,
+                    "sku": "98D6AA9",
+                    "bulk_sku": None
+                }],
+                "start": "2019-02-20T15:00:00Z",
+                "end": "2019-05-22T23:30:00Z",
+                "enrollment_start": None,
+                "enrollment_end": None,
+                "pacing_type": "instructor_paced",
+                "type": "verified",
+                "status": "published",
+                "course": "MITx+15.071x",
+                "full_description": "<p>Full Description</p>",
+                "announcement": "2018-12-19T15:50:34Z",
+                "video": {
+                    "src": "http://www.youtube.com/watch?v=1BMSOBCe07k",
+                    "description": None,
+                    "image": {
+                        "src": "image_source",
+                        "description": None,
+                        "height": None,
+                        "width": None
+                    }
+                },
+                "content_language": "en-us",
+                "license": "",
+                "outcome": "outcome",
+                "transcript_languages": ["en-us"],
+                "instructors": [],
+                "staff": [{
+                    "uuid": "32720429-8290-4ac5-a62d-386fb3c4be80",
+                    "salutation": None,
+                    "given_name": "Dimitris",
+                    "family_name": "Bertsimas",
+                    "bio": "Dimitris Bertsimas bio",
+                    "slug": "dimitris-bertsimas",
+                    "position": {
+                        "title": "Boeing Professor of Operations Research ",
+                        "organization_name": "MIT",
+                        "organization_id": 27,
+                        "organization_override": "MIT",
+                        "organization_marketing_url": "https://www.edx.org/school/mitx"
+                    },
+                    "areas_of_expertise": [],
+                    "profile_image": {
+                        "medium": {
+                            "height": 110,
+                            "url": "profile_image",
+                            "width": 110
+                        }
+                    },
+                    "works": [],
+                    "urls": {
+                        "facebook": None,
+                        "blog": None,
+                        "twitter": None
+                    },
+                    "urls_detailed": [],
+                    "email": None,
+                    "profile_image_url": "profile_image_url",
+                    "major_works": "",
+                    "published": True
+                }, {
+                    "uuid": "5bb098d8-76fb-450b-9e59-3a60b041f645",
+                    "salutation": None,
+                    "given_name": "Allison",
+                    "family_name": "O'Hair",
+                    "bio": "bio",
+                    "slug": "allison-ohair",
+                    "position": {
+                        "title": "Lecturer",
+                        "organization_name": "Stanford University",
+                        "organization_id": None,
+                        "organization_override": "Stanford University",
+                        "organization_marketing_url": None
+                    },
+                    "areas_of_expertise": [],
+                    "profile_image": {
+                        "medium": {
+                            "height": 110,
+                            "url": "profile_image_url",
+                            "width": 110
+                        }
+                    },
+                    "works": [],
+                    "urls": {
+                        "facebook": None,
+                        "blog": None,
+                        "twitter": None
+                    },
+                    "urls_detailed": [],
+                    "email": None,
+                    "profile_image_url": "profile_image_url",
+                    "major_works": "",
+                    "published": True
+                }],
+                "min_effort": 10,
+                "max_effort": 15,
+                "weeks_to_complete": 13,
+                "modified": "2019-01-11T18:27:16.466621Z",
+                "level_type": "Intermediate",
+                "availability": "Starting Soon",
+                "mobile_available": True,
+                "hidden": False,
+                "reporting_type": "mooc",
+                "eligible_for_financial_aid": True,
+                "first_enrollable_paid_seat_price": 150,
+                "has_ofac_restrictions": False,
+                "enrollment_count": 1619,
+                "recent_enrollment_count": 1619
+            }],
+            "entitlements": [],
+            "owners": [{
+                "uuid": "2a73d2ce-c34a-4e08-8223-83bca9d2f01d",
+                "key": "MITx",
+                "name": "Massachusetts Institute of Technology",
+                "certificate_logo_image_url": "https://edxuploads.s3.amazonaws.com/organization_logos/logo-mitx.png",
+                "description": "description",
+                "homepage_url": "",
+                "tags": ["charter", "founder"],
+                "logo_image_url": "logo_image_url",
+                "marketing_url": "https://www.edx.org/school/mitx"
+            }],
+            "image": {
+                "src": "image_src",
+                "height": None,
+                "width": None,
+                "description": None
+            },
+            "short_description": "short_description",
+            "full_description": "full description",
+            "level_type": "Intermediate",
+            "subjects": [{
+                "name": "Data Analysis & Statistics",
+                "subtitle": "subtitle",
+                "description": "description",
+                "banner_image_url": "banner_image_url",
+                "card_image_url": "https://www.edx.org/sites/default/files/subject/image/card/data-science.jpg",
+                "slug": "data-analysis-statistics",
+                "uuid": "a168a80a-4b6c-4d92-9f1d-4c235206feaf"
+            }],
+            "prerequisites": [],
+            "prerequisites_raw": "prerequisites_raw",
+            "expected_learning_items": [],
+            "video": {
+                "src": "http://www.youtube.com/watch?v=1BMSOBCe07k",
+                "description": None,
+                "image": {
+                    "src": "video_image_src",
+                    "description": None,
+                    "height": None,
+                    "width": None
+                }
+            },
+            "sponsors": [],
+            "modified": "2019-01-11T18:07:29.593570Z",
+            "marketing_url": "marketing_url",
+            "syllabus_raw": "",
+            "outcome": "outcome",
+            "original_image": {
+                "src": "original_image_src",
+                "height": None,
+                "width": None,
+                "description": None
+            },
+            "card_image_url": "card_image_url",
+            "canonical_course_run_key": "MITx/15.071x/1T2014",
+            "extra_description": None,
+            "additional_information": "",
+            "faq": "faq",
+            "learner_testimonials": "",
+            "enrollment_count": 90600,
+            "recent_enrollment_count": 14365,
+            "topics": []
+        }
+
+    def test_parse_valid_mitx_json_data(self):
+        """
+        Test parsing valid mitx json data
+        """
+        parse_mitx_json_data(self.valid_data)
+        courses_count = Course.objects.count()
+        self.assertEqual(courses_count, 1)
+
+    def test_parse_invalid_mitx_json_data(self):
+        """
+        Test parsing invalid mitx json data
+        """
+        invalid_data = copy.copy(self.valid_data)
+        invalid_data["course_runs"][0]["key"] = ""
+        parse_mitx_json_data(invalid_data)
+        courses_count = Course.objects.count()
+        self.assertEqual(courses_count, 0)
+
+    def test_parse_wrong_owner_json_data(self):
+        """
+        Test parsing valid edx data from a different owner.
+        """
+        invalid_data = copy.copy(self.valid_data)
+        invalid_data["owners"][0]["key"] = "FakeUniversity"
+        parse_mitx_json_data(invalid_data)
+        courses_count = Course.objects.count()
+        self.assertEqual(courses_count, 0)


### PR DESCRIPTION
#### What are the relevant tickets?
Continues work on #15 #17 
Closes #31 

#### What's this PR do?
Moves the mitx catalog url to an environment variable.
Adds tests for mitx json parsing.
Handles some cases of missing data better (image_src and image_description).
Refactors year and semester parsing into its own function.
Adds a check to make sure each course is owned by MITx or MITx_PRO
Handles error responses from the EDX API.

#### How should this be manually tested?
Open the project in the shell and manually run get_edx_data(). You will need to add the catalog url to environment variables (`EDX_API_URL=https://api.edx.org/catalog/v1/catalogs/10/courses`). 