### PR TITLE
Include related object serializers in CourseSerializer

### DIFF
--- a/course_catalog/factories.py
+++ b/course_catalog/factories.py
@@ -1,0 +1,78 @@
+"""Factories for making test data"""
+import factory
+from factory.django import DjangoModelFactory
+from factory.fuzzy import FuzzyChoice
+
+from course_catalog.constants import PlatformType
+from course_catalog.models import Course, CourseInstructor, CourseTopic, CoursePrice
+
+# pylint: disable=unused-argument,unnecessary-lambda
+
+
+class CourseInstructorFactory(DjangoModelFactory):
+    """Factory for course instructors"""
+
+    first_name = factory.Faker("name")
+    last_name = factory.Faker("name")
+
+    class Meta:
+        model = CourseInstructor
+
+
+class CourseTopicFactory(DjangoModelFactory):
+    """Factory for course topics"""
+
+    name = factory.Sequence(lambda n: "Topic %03d" % n)
+
+    class Meta:
+        model = CourseTopic
+
+
+class CoursePriceFactory(DjangoModelFactory):
+    """Factory for course prices"""
+
+    price = factory.Sequence(lambda n: float(n))
+    mode = factory.Faker("word")
+
+    class Meta:
+        model = CoursePrice
+
+
+class CourseFactory(DjangoModelFactory):
+    """Factory for Courses"""
+
+    course_id = factory.Sequence(lambda n: "COURSE%03d.MIT" % n)
+    platform = FuzzyChoice((PlatformType.mitx.value, PlatformType.ocw.value))
+
+    @factory.post_generation
+    def instructors(self, create, extracted, **kwargs):
+        """Create instructors for course"""
+        if not create:
+            return
+
+        if extracted:
+            for instructor in extracted:
+                self.instructors.add(instructor)
+
+    @factory.post_generation
+    def topics(self, create, extracted, **kwargs):
+        """Create topics for course"""
+        if not create:
+            return
+
+        if extracted:
+            for topic in extracted:
+                self.topics.add(topic)
+
+    @factory.post_generation
+    def prices(self, create, extracted, **kwargs):
+        """Create prices for course"""
+        if not create:
+            return
+
+        if extracted:
+            for price in extracted:
+                self.prices.add(price)
+
+    class Meta:
+        model = Course

--- a/course_catalog/factories.py
+++ b/course_catalog/factories.py
@@ -6,7 +6,7 @@ from factory.fuzzy import FuzzyChoice
 from course_catalog.constants import PlatformType
 from course_catalog.models import Course, CourseInstructor, CourseTopic, CoursePrice
 
-# pylint: disable=unused-argument,unnecessary-lambda
+# pylint: disable=unused-argument
 
 
 class CourseInstructorFactory(DjangoModelFactory):
@@ -31,7 +31,7 @@ class CourseTopicFactory(DjangoModelFactory):
 class CoursePriceFactory(DjangoModelFactory):
     """Factory for course prices"""
 
-    price = factory.Sequence(lambda n: float(n))
+    price = factory.Sequence(lambda n: 0.00 + float(n))
     mode = factory.Faker("word")
 
     class Meta:

--- a/course_catalog/serializers.py
+++ b/course_catalog/serializers.py
@@ -37,6 +37,10 @@ class CourseSerializer(serializers.ModelSerializer):
     """
     Serializer for Course model
     """
+    instructors = CourseInstructorSerializer(read_only=True, many=True, allow_null=True)
+    topics = CourseTopicSerializer(read_only=True, many=True, allow_null=True)
+    prices = CoursePriceSerializer(read_only=True, many=True, allow_null=True)
+
     class Meta:
         model = Course
         fields = "__all__"

--- a/course_catalog/serializers_test.py
+++ b/course_catalog/serializers_test.py
@@ -1,168 +1,183 @@
 """
 Test course_catalog serializers
 """
-from django.test import TestCase
-from .serializers import OCWCourseSerializer
+import pytest
+
+from course_catalog.factories import (
+    CourseFactory,
+    CourseTopicFactory,
+    CoursePriceFactory,
+    CourseInstructorFactory,
+)
+from course_catalog.serializers import OCWCourseSerializer, CourseSerializer
+
+pytestmark = pytest.mark.django_db
 
 
-class OCWSerializerTest(TestCase):
+def test_serialize_course_related_models():
     """
-    Tests OCWSerializer
+    Verify that a serialized course contains attributes for related objects
     """
-    def test_deserializing_a_valid_ocw_course(self):
-        """
-        Verify that OCWSerializer successfully de-serialize a JSON object and create Course model instance
-        """
-        valid_ocw_course_master_obj = {
-            'uid': 'e9387c256bae4ca99cce88fd8b7f8272',
-            'title': 'Undergraduate Thesis Tutorial',
-            'description': '<p>This course is a series of lectures on prospectus and thesis writing</p>',
-            'course_level': 'Undergraduate',
-            'from_semester': 'Fall',
-            'from_year': '2015',
-            'language': 'en-US',
-            'image_src': 'https://s3.us-east-2.amazonaws.com/alizagarantestbucket/test_folder/'
-                         'f49d46243a5c035597e75941ffec830a_22-thtf15.jpg',
-            'image_description': 'Photo of hardbound academic theses on library shelves.',
-            'platform': 'OCW',
-            'creation_date': '2016-01-08 22:35:55.151996+00:00',
-            'expiration_date': None,
-            'raw_json': {'name': 'ali', 'whatever': 'something', 'llist': [1, 2, 3]},
-            'instructors': [
-                {
-                    'middle_initial': '',
-                    'first_name': 'Michael',
-                    'last_name': 'Short',
-                    'suffix': '',
-                    'title': '',
-                    'mit_id': '',
-                    'department': '',
-                    'directory_title': '',
-                    'uid': 'd9ca5631c6936252866d63683c0c452e'
-                },
-                {
-                    'middle_initial': '',
-                    'first_name': 'Jane',
-                    'last_name': 'Kokernak',
-                    'suffix': '',
-                    'title': '',
-                    'mit_id': '',
-                    'department': '',
-                    'directory_title': '',
-                    'uid': 'bb1e26b5f5c9c054ddae8a2988ad7b42'
-                },
-                {
-                    'middle_initial': '',
-                    'first_name': 'Christine',
-                    'last_name': 'Sherratt',
-                    'suffix': '',
-                    'title': '',
-                    'mit_id': '',
-                    'department': '',
-                    'directory_title': '',
-                    'uid': 'a39f692061a70a105c25b15374c02c92'
-                }
-            ],
-            'course_collections': [
-                {
-                    'ocw_feature': 'Engineering',
-                    'ocw_subfeature': 'Nuclear Engineering',
-                    'ocw_feature_url': '',
-                    'ocw_speciality': '',
-                    'ocw_feature_notes': ''
-                },
-                {
-                    'ocw_feature': 'Humanities',
-                    'ocw_subfeature': 'Literature',
-                    'ocw_feature_url': '',
-                    'ocw_speciality': 'Academic Writing',
-                    'ocw_feature_notes': ''
-                }
-            ],
-            'price': {
-                'price': 0.0,
-                'mode': 'audit',
-                'upgrade_deadline': None
-            }
-        }
-        serializer = OCWCourseSerializer(data=valid_ocw_course_master_obj)
-        self.assertTrue(
-            serializer.is_valid()
-        )
+    course = CourseFactory(
+        topics=CourseTopicFactory.create_batch(3),
+        prices=CoursePriceFactory.create_batch(2),
+        instructors=CourseInstructorFactory.create_batch(2),
+    )
+    serializer = CourseSerializer(course)
+    assert len(serializer.data["prices"]) == 2
+    for attr in ("mode", "price"):
+        assert attr in serializer.data["prices"][0].keys()
+    assert len(serializer.data["instructors"]) == 2
+    for attr in ("first_name", "last_name"):
+        assert attr in serializer.data["instructors"][0].keys()
+    assert len(serializer.data["topics"]) == 3
+    assert "name" in serializer.data["topics"][0].keys()
 
-    def test_deserialzing_an_invalid_ocw_course(self):
-        """
-        Verifies that OCWSerializer validation works correctly if the OCW course has invalid values
-        """
-        invalid_ocw_course_master_obj = {
-            'uid': '',
-            'title': '',
-            'description': '',
-            'course_level': '',
-            'from_semester': 'Fall',
-            'from_year': '2015',
-            'language': 'en-US',
-            'image_src': '',
-            'image_description': 'Photo of hardbound academic theses on library shelves.',
-            'platform': 'OCW',
-            'creation_date': '2016/01/08 22:35:55.151996+00:00',
-            'expiration_date': None,
-            'raw_json': {},
-            'instructors': [
-                {
-                    'middle_initial': '',
-                    'first_name': 'Michael',
-                    'suffix': '',
-                    'title': '',
-                    'mit_id': '',
-                    'department': '',
-                    'directory_title': '',
-                    'uid': 'd9ca5631c6936252866d63683c0c453e'
-                },
-                {
-                    'middle_initial': '',
-                    'first_name': 'Jane',
-                    'last_name': 'Kokernak',
-                    'suffix': '',
-                    'title': '',
-                    'mit_id': '',
-                    'department': '',
-                    'directory_title': '',
-                    'uid': 'bb1e26b5f5c9c054ddae8a2988ad7b48'
-                },
-                {
-                    'middle_initial': '',
-                    'last_name': 'Sherratt',
-                    'suffix': '',
-                    'title': '',
-                    'mit_id': '',
-                    'department': '',
-                    'directory_title': '',
-                    'uid': 'a39f692061a70a105c25b15374c02c95'
-                }
-            ],
-            'course_collections': [
-                {
-                    'ocw_feature': 'Engineering',
-                    'ocw_subfeature': 'Nuclear Engineering',
-                    'ocw_feature_url': '',
-                    'ocw_speciality': '',
-                    'ocw_feature_notes': ''
-                },
-                {
-                    'ocw_feature': 'Humanities',
-                    'ocw_subfeature': 'Literature',
-                    'ocw_feature_url': '',
-                    'ocw_speciality': 'Academic Writing',
-                    'ocw_feature_notes': ''
-                }
-            ],
-            'price': {
-                'price': 0.0,
-                'upgrade_deadline': None
-            }
-        }
-        serializer = OCWCourseSerializer(data=invalid_ocw_course_master_obj)
-        self.assertFalse(
-            serializer.is_valid()
-        )
+
+def test_deserializing_a_valid_ocw_course():
+    """
+    Verify that OCWSerializer successfully de-serialize a JSON object and create Course model instance
+    """
+    valid_ocw_course_master_obj = {
+        "uid": "e9387c256bae4ca99cce88fd8b7f8272",
+        "title": "Undergraduate Thesis Tutorial",
+        "description": "<p>This course is a series of lectures on prospectus and thesis writing</p>",
+        "course_level": "Undergraduate",
+        "from_semester": "Fall",
+        "from_year": "2015",
+        "language": "en-US",
+        "image_src": "https://s3.us-east-2.amazonaws.com/alizagarantestbucket/test_folder/"
+                     "f49d46243a5c035597e75941ffec830a_22-thtf15.jpg",
+        "image_description": "Photo of hardbound academic theses on library shelves.",
+        "platform": "OCW",
+        "creation_date": "2016-01-08 22:35:55.151996+00:00",
+        "expiration_date": None,
+        "raw_json": {"name": "ali", "whatever": "something", "llist": [1, 2, 3]},
+        "instructors": [
+            {
+                "middle_initial": "",
+                "first_name": "Michael",
+                "last_name": "Short",
+                "suffix": "",
+                "title": "",
+                "mit_id": "",
+                "department": "",
+                "directory_title": "",
+                "uid": "d9ca5631c6936252866d63683c0c452e",
+            },
+            {
+                "middle_initial": "",
+                "first_name": "Jane",
+                "last_name": "Kokernak",
+                "suffix": "",
+                "title": "",
+                "mit_id": "",
+                "department": "",
+                "directory_title": "",
+                "uid": "bb1e26b5f5c9c054ddae8a2988ad7b42",
+            },
+            {
+                "middle_initial": "",
+                "first_name": "Christine",
+                "last_name": "Sherratt",
+                "suffix": "",
+                "title": "",
+                "mit_id": "",
+                "department": "",
+                "directory_title": "",
+                "uid": "a39f692061a70a105c25b15374c02c92",
+            },
+        ],
+        "course_collections": [
+            {
+                "ocw_feature": "Engineering",
+                "ocw_subfeature": "Nuclear Engineering",
+                "ocw_feature_url": "",
+                "ocw_speciality": "",
+                "ocw_feature_notes": "",
+            },
+            {
+                "ocw_feature": "Humanities",
+                "ocw_subfeature": "Literature",
+                "ocw_feature_url": "",
+                "ocw_speciality": "Academic Writing",
+                "ocw_feature_notes": "",
+            },
+        ],
+        "price": {"price": 0.0, "mode": "audit", "upgrade_deadline": None},
+    }
+    serializer = OCWCourseSerializer(data=valid_ocw_course_master_obj)
+    assert serializer.is_valid()
+
+
+def test_deserialzing_an_invalid_ocw_course():
+    """
+    Verifies that OCWSerializer validation works correctly if the OCW course has invalid values
+    """
+    invalid_ocw_course_master_obj = {
+        "uid": "",
+        "title": "",
+        "description": "",
+        "course_level": "",
+        "from_semester": "Fall",
+        "from_year": "2015",
+        "language": "en-US",
+        "image_src": "",
+        "image_description": "Photo of hardbound academic theses on library shelves.",
+        "platform": "OCW",
+        "creation_date": "2016/01/08 22:35:55.151996+00:00",
+        "expiration_date": None,
+        "raw_json": {},
+        "instructors": [
+            {
+                "middle_initial": "",
+                "first_name": "Michael",
+                "suffix": "",
+                "title": "",
+                "mit_id": "",
+                "department": "",
+                "directory_title": "",
+                "uid": "d9ca5631c6936252866d63683c0c453e",
+            },
+            {
+                "middle_initial": "",
+                "first_name": "Jane",
+                "last_name": "Kokernak",
+                "suffix": "",
+                "title": "",
+                "mit_id": "",
+                "department": "",
+                "directory_title": "",
+                "uid": "bb1e26b5f5c9c054ddae8a2988ad7b48",
+            },
+            {
+                "middle_initial": "",
+                "last_name": "Sherratt",
+                "suffix": "",
+                "title": "",
+                "mit_id": "",
+                "department": "",
+                "directory_title": "",
+                "uid": "a39f692061a70a105c25b15374c02c95",
+            },
+        ],
+        "course_collections": [
+            {
+                "ocw_feature": "Engineering",
+                "ocw_subfeature": "Nuclear Engineering",
+                "ocw_feature_url": "",
+                "ocw_speciality": "",
+                "ocw_feature_notes": "",
+            },
+            {
+                "ocw_feature": "Humanities",
+                "ocw_subfeature": "Literature",
+                "ocw_feature_url": "",
+                "ocw_speciality": "Academic Writing",
+                "ocw_feature_notes": "",
+            },
+        ],
+        "price": {"price": 0.0, "upgrade_deadline": None},
+    }
+    serializer = OCWCourseSerializer(data=invalid_ocw_course_master_obj)
+    assert serializer.is_valid() is False


### PR DESCRIPTION
#### What are the relevant tickets?
Closes #34 

#### What's this PR do?
Includes `CourseTopicSerializer`, `CoursePriceSerializer`, and `CourseInstructorSerializer` in `CourseSerializer`

#### How should this be manually tested?
- MITx data should still import successfully
- If you run the following, you should see the CoursePrice attributes and values rather than a list of CoursePrice object id's:
```python
from course_catalog.serializers import *
from course_catalog.models import *
course = Course.objects.first()
serializer = CourseSerializer(course)
serializer.data['prices']

>>
[OrderedDict([('id', 56),
              ('created_on', '2019-01-15T14:00:04.155972Z'),
              ('updated_on', '2019-01-15T14:00:04.155997Z'),
              ('price', '0.00'),
              ('mode', 'honor'),
              ('upgrade_deadline', None)]),
 OrderedDict([('id', 57),
              ('created_on', '2019-01-15T14:00:04.169276Z'),
              ('updated_on', '2019-01-15T14:00:04.169300Z'),
              ('price', '50.00'),
              ('mode', 'verified'),
              ('upgrade_deadline', '2015-06-30T23:30:00Z')])]
```
