### PR TITLE
Save raw_json as json for edx courses

### DIFF
--- a/course_catalog/tasks_helpers.py
+++ b/course_catalog/tasks_helpers.py
@@ -86,7 +86,7 @@ def parse_mitx_json_data(course_data):
             "image_src": (course_run.get("image") or {}).get("src"),
             "image_description": (course_run.get("image") or {}).get("description"),
             "last_modified": max_modified,
-            "raw_json": json.dumps(course_data),
+            "raw_json": course_data,
         }
 
         course_serializer = CourseSerializer(data=course_fields, instance=course_instance)


### PR DESCRIPTION
#### What are the relevant tickets?
N/A

#### What's this PR do?
Saves the `raw_json` field as JSON instead of string for mitx courses

#### How should this be manually tested?
Run `get_edx_data` and verify that the `raw_json` field of the courses are JSON, not strings.
