### PR TITLE
Updates requirements

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -15,4 +15,4 @@ requests
 uwsgi
 djangorestframework
 django-extensions
-ocw-data-parser==0.1.9
+ocw-data-parser==0.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,7 +32,7 @@ jedi==0.13.1              # via ipython
 jmespath==0.9.3           # via boto3, botocore
 kombu==4.2.1              # via celery, django-server-status
 newrelic==4.8.0.110
-ocw-data-parser==0.1.9
+ocw-data-parser==0.2.0
 parso==0.3.1              # via jedi
 pexpect==4.6.0            # via ipython
 pickleshare==0.7.5        # via ipython


### PR DESCRIPTION
#### What's this PR do?
Updates `ocw-data-parser` to verision `0.2.0`. This will improve the way we look for `chp_image` for a course.  Instead of always looking in `2.json`, we look for *CourseHomeSection* JSON first, then extract `chp_image` value from it.

This change fixes the issue missing course image for `courses/comparative-media-studies-writing/21w-034-science-writing-and-new-media-perspectives-on-medicine-and-public-health-fall-2016`