### PR TITLE
Exposes api to get OCW course sync report

### DIFF
--- a/course_catalog/urls.py
+++ b/course_catalog/urls.py
@@ -19,7 +19,7 @@ from django.contrib import admin
 from django.urls import path
 from rest_framework.routers import DefaultRouter
 
-from course_catalog.views import index, CourseViewSet
+from course_catalog.views import index, CourseViewSet, ocw_course_report
 
 urlpatterns = [
     path('admin/', admin.site.urls),
@@ -27,6 +27,7 @@ urlpatterns = [
 
     # Example view
     path('', index, name='course_catalog-index'),
+    path('ocw-course-report/', ocw_course_report, name="course_catalog-ocw_course_report")
 ]
 
 if settings.DEBUG:

--- a/course_catalog/views.py
+++ b/course_catalog/views.py
@@ -7,12 +7,14 @@ from django.conf import settings
 from django.shortcuts import render
 from django.utils import timezone
 from rest_framework import viewsets
-from rest_framework.decorators import action
+from rest_framework.decorators import action, api_view
 from rest_framework.pagination import LimitOffsetPagination
+from rest_framework.response import Response
 
 from course_catalog.models import Course
 from course_catalog.serializers import CourseSerializer
 from course_catalog.templatetags.render_bundle import public_path
+from course_catalog.constants import PlatformType
 # pylint:disable=unused-argument
 
 
@@ -29,6 +31,21 @@ def index(request):
     return render(request, "index.html", context={
         "js_settings_json": json.dumps(js_settings),
     })
+
+
+@api_view(['GET'])
+def ocw_course_report(request):
+    """
+    Returns a JSON object reporting OCW course sync statistics
+    """
+    ocw_courses = Course.objects.filter(platform=PlatformType.ocw.value)
+    published_ocw_courses_with_image = ocw_courses.filter(published=True, image_src__isnull=False).count()
+    unpublished_ocw_courses = ocw_courses.filter(published=False).count()
+    ocw_courses_without_image = ocw_courses.filter(image_src="").count()
+    return Response({"total_number_of_ocw_courses": ocw_courses.count(),
+                     "published_ocw_courses_with_image": published_ocw_courses_with_image,
+                     "unpublished_ocw_courses": unpublished_ocw_courses,
+                     "ocw_courses_without_image": ocw_courses_without_image})
 
 
 class CoursePagination(LimitOffsetPagination):


### PR DESCRIPTION
#### What's this PR do?
Exposes api to get OCW Course sync report

#### How should this be manually tested?
By getting: `http://localhost:8073/ocw-course-report/`

#### Where should the reviewer start?
views.py